### PR TITLE
Update RebootMadDevice.py

### DIFF
--- a/MAD_plugin/RebootMadDevice.py
+++ b/MAD_plugin/RebootMadDevice.py
@@ -168,7 +168,7 @@ class RebootMadDevice(mapadroid.utils.pluginBase.Plugin):
                     last_mitm_data = mitm_stats['origin_status'][device_origin]['latest_data']
                     last_proto_data = device['lastProtoDateTime']
                     sleep_time = device['currentSleepTime']
-                    data_plus_sleep = last_proto_data + sleep_time
+                    data_plus_sleep = last_proto_data or 0 + sleep_time
                     try:
                         last_reboot_time = self._reboothistory[device_origin]['last_reboot_time']
                         reboot_count = self._reboothistory[device_origin]['reboot_count']


### PR DESCRIPTION
Fix for https://github.com/GhostTalker/RebootMadDevice/issues/8

Example of situation that can occour is as follows:

- New ATV/Device added to MAD. 
- No previous connection, reports None. 
- None throws error, or 0 allows calculation to occour. 