### PR TITLE
re-add removed lines from config.ini.example

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -12,12 +12,13 @@ ADB_PORT: 5555
 LOG_MODE: console
 LOG_LEVEL: INFO
 
-[MAD_DATABASE]
+[DATABASE]
 DB_HOST: <IP Adresse>
 DB_PORT: 3306
 DB_NAME: <mad database>
 DB_USER: <db user>
 DB_PASS: <db password>
+DB_TYPE: <MAD/RDM>
 
 [REBOOTOPTIONS]
 TRY_ADB_FIRST = <True/False>


### PR DESCRIPTION
Commit: 9ff419fc6a7164ba0b3d96bd6d044b75a1d2ef98 breaks the config as it removes the previously added lines for RDM support.